### PR TITLE
Enable verification checks on CI

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Run tests
       run: |
         sbt update
+        sbt compile
         sbt test
 
   verify:


### PR DESCRIPTION
__Goals?__
Allow verification and improve state of test hob

__How does it improve on the current state of verified components?__
Verification is run always on a clean instance of ubuntu.