### PR TITLE
Add more supervisor errors.

### DIFF
--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/fork/PeerList.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/fork/PeerList.scala
@@ -19,14 +19,14 @@ case class PeerList[Id, Instance](
       !witnessesIds.contains(primaryId) && !faultyNodeIds.contains(primaryId) && !fullNodeIds.contains(primaryId)
   )
 
+  def primary: Instance = mapping(primaryId)
+
   def witnesses: List[Instance] = {
     witnessesIds.map(witness ⇒ {
       require(mapping.contains(witness))
       mapping(witness)
     })
   }
-
-  def primary: Instance = mapping(primaryId)
 
   def markPrimaryAsFaulty: PeerList[Id, Instance] = {
     require(witnessesIds.nonEmpty)

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
@@ -32,7 +32,7 @@ sealed class DefaultForkDetector(private val hasher: Hasher) extends ForkDetecto
         witnessVerificationResult.outcome match {
           case lang.Left(_) ⇒ Some(Forked(targetLightBlock, witnessBlock))
           case lang.Right(content) if content == ExpiredTrustedState ⇒ Some(Forked(targetLightBlock, witnessBlock))
-          case lang.Right(_) ⇒ Some(Faulty(witnessBlock))
+          case lang.Right(reason) ⇒ Some(Faulty(witnessBlock, reason))
         }
       }
     })

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/ForkDetection.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/ForkDetection.scala
@@ -1,6 +1,7 @@
 package ch.epfl.ognjanovic.stevan.tendermint.light
 
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.MultiStepVerifier
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.VerificationError
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.LightBlock
 
 object ForkDetection {
@@ -26,8 +27,7 @@ object ForkDetection {
 
   case class Forked(primary: LightBlock, witness: LightBlock) extends Fork
 
-  // TODO add reason for error
-  case class Faulty(block: LightBlock) extends Fork
+  case class Faulty(block: LightBlock, verificationError: VerificationError) extends Fork
 
   sealed trait ForkDetectionResult
 

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/Supervisor.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/Supervisor.scala
@@ -1,6 +1,7 @@
 package ch.epfl.ognjanovic.stevan.tendermint.light
 
-import ch.epfl.ognjanovic.stevan.tendermint.verified.types.{Height, LightBlock}
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.VerificationError
+import ch.epfl.ognjanovic.stevan.tendermint.verified.types.{Height, LightBlock, PeerId}
 
 /**
  * Trait encapsulating full light client implementation with verification, fork detection and evidence reporting.
@@ -29,5 +30,53 @@ trait Supervisor {
 }
 
 object Supervisor {
-  trait Error
+  sealed trait Error
+
+  case class Io(exception: Exception) extends Error {
+    override def toString: String = "Verification experienced an IO exception:\n" + exception.toString
+  }
+
+  case class Store(exception: Exception) extends Error {
+    override def toString: String = "There was an exception during storing light blocks:\n" + exception.toString
+  }
+
+  case object NoPrimary extends Error {
+    override def toString: String = "Light client has no more candidates for a primary peer."
+  }
+
+  case object NoWitnesses extends Error {
+    override def toString: String = "There are no more witnesses to swap with."
+  }
+
+  case object NoWitnessLeft extends Error {
+    override def toString: String = "There are no more witnesses to use for fork detection."
+  }
+
+  case class ForkDetected(peers: Seq[PeerId]) extends Error {
+    override def toString: String = "Fork detected for following peers:\n" + peers.toString()
+  }
+
+  case object NoValidVerificationState extends Error {
+    override def toString: String = "Verification can not proceed with no Trusted or Verified light block."
+  }
+
+  case object NoTrustedState extends Error {
+    override def toString: String = "Fork detection can not proceed if there are no trusted light blocks."
+  }
+
+  case class TargetLowerThanTrustedState(targetHeight: Height, trustedHeight: Height) extends Error {
+
+    override def toString: String =
+      "Forward verification can not proceed with a target header lower than the current trusted"
+
+  }
+
+  case class VerificationStateOutsideOfTrustingPeriod(lightBlock: LightBlock) extends Error {
+    override def toString: String = "Verification failed because of expired state:" + lightBlock.toString
+  }
+
+  case class InvalidLightBlock(error: VerificationError) extends Error {
+    override def toString: String = "Verification of a light block failed because of: " + error
+  }
+
 }


### PR DESCRIPTION
__Goals?__
Add errors as in tendermint-rs related to #69 but does not cover the errors task fully.

__Description?__
Ported errors from tendermint-rs.

__Possible problems?__
Not all errors from here are used, one problem is that Rust has a different error handling capability and this needs to be addressed in subsequent PRs.