### PR TITLE
Safe termination of thread pool.

### DIFF
--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/Handle.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/Handle.scala
@@ -23,7 +23,7 @@ trait Handle {
   def verifyToHeight(height: Height): Future[Either[LightBlock, Supervisor.Error]]
 
   /**
-   * Closes this handle. // TODO this should probably be named differently
+   * Closes this handle along with closing of all resources associated with it, like thread pools, etc.
    */
   def terminate()
 }


### PR DESCRIPTION
__Goals?__
Previously the termination of `Supervisor` event loop was very optimistic with a simple shutdown and hope for the best. The current implementation takes a much more structured approach with timeouts on termination of the pool.

__Description?__
- implemented the recommended approach to shutting down `ExecutorService`