### PR TITLE
ExecutorService shared between handles.

### DIFF
--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
@@ -37,7 +37,7 @@ object EventLoopClient {
       extends Supervisor {
 
     // force sharing between constructed handles, when there is a need for multiple threads to use the same supervisor
-    //  recommended approach is to wrap the Handle to prevent unwanted closing
+    // recommended approach is to wrap the Handle to prevent unwanted closing
     private lazy val executorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
     override def verifyToHeight(height: Height): Either[LightBlock, Supervisor.Error] = {


### PR DESCRIPTION
__Goals?__
Prevent users from creating multiple single threaded executor services for each handle basically breaking concurrency model of `EventLoopSupervisor`

__Description?__
- assign an executor service to the `EventLoopSupervisor` and force all returned handles to use the same `ExecutorService`
- users need to be aware that closing one of the returned handles closes the service
- intended usage is get one handle from the supervisor and than wrap it to prevent unwanted closing of the service