### PR TITLE
Rename UntrustedState to FetchedStack

### DIFF
--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/integration/ModelIntegration.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/integration/ModelIntegration.scala
@@ -3,11 +3,11 @@ package ch.epfl.ognjanovic.stevan.tendermint.verified.integration
 import ch.epfl.ognjanovic.stevan.tendermint.verified.blockchain.BlockchainStates.BlockchainState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light._
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.CommitValidators.DefaultCommitValidator
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.InMemoryUntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockProviders.LightBlockProvider
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockValidators.DummyLightBlockValidator
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.NextHeightCalculators.NextHeightCalculator
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.TrustVerifiers.DefaultTrustVerifier
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStates.InMemoryUntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.VerificationError
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.{SimpleVerifiedState, VerifiedState}
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types._

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/integration/ModelIntegration.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/integration/ModelIntegration.scala
@@ -32,10 +32,10 @@ object ModelIntegration {
 
     val verifiedState: VerifiedState =
       SimpleVerifiedState(trustedSignedHeader, VotingPowerVerifiers.defaultVotingPowerVerifier)
-    val untrustedState = InMemoryFetchedStack(heightToVerify, List.empty)
-    assert(untrustedState.peek().forall(heightToVerify < _.header.height))
+    val fetchedStack = InMemoryFetchedStack(heightToVerify, List.empty)
+    assert(fetchedStack.peek().forall(heightToVerify < _.header.height))
     assert(verifiedState.currentHeight() < heightToVerify)
-    assert(heightToVerify <= untrustedState.targetLimit)
+    assert(heightToVerify <= fetchedStack.targetLimit)
 
     val lightBlockVerifier = DefaultTrustVerifier()
     MultiStepVerifier(
@@ -46,7 +46,7 @@ object ModelIntegration {
         DefaultCommitValidator(VotingPowerVerifiers.defaultVotingPowerVerifier, DummyCommitSignatureVerifier())),
       nextHeightCalculator
     )
-      .verifyUntrusted(verifiedState, untrustedState)
+      .verifyUntrusted(verifiedState, fetchedStack)
       .outcome
   }
 

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/integration/ModelIntegration.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/integration/ModelIntegration.scala
@@ -3,7 +3,7 @@ package ch.epfl.ognjanovic.stevan.tendermint.verified.integration
 import ch.epfl.ognjanovic.stevan.tendermint.verified.blockchain.BlockchainStates.BlockchainState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light._
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.CommitValidators.DefaultCommitValidator
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.InMemoryUntrustedState
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.InMemoryFetchedStack
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockProviders.LightBlockProvider
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockValidators.DummyLightBlockValidator
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.NextHeightCalculators.NextHeightCalculator
@@ -32,8 +32,8 @@ object ModelIntegration {
 
     val verifiedState: VerifiedState =
       SimpleVerifiedState(trustedSignedHeader, VotingPowerVerifiers.defaultVotingPowerVerifier)
-    val untrustedState = InMemoryUntrustedState(heightToVerify, List.empty)
-    assert(untrustedState.bottomHeight().forall(heightToVerify < _))
+    val untrustedState = InMemoryFetchedStack(heightToVerify, List.empty)
+    assert(untrustedState.peek().forall(heightToVerify < _.header.height))
     assert(verifiedState.currentHeight() < heightToVerify)
     assert(heightToVerify <= untrustedState.targetLimit)
 

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/FetchedStacks.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/FetchedStacks.scala
@@ -5,7 +5,7 @@ import stainless.annotation.pure
 import stainless.collection.{Cons, List}
 import stainless.lang._
 
-object UntrustedStates {
+object FetchedStacks {
 
   @scala.annotation.tailrec
   private def pendingInvariant(pending: List[LightBlock]): Boolean = {
@@ -31,7 +31,7 @@ object UntrustedStates {
         (!res && bottomHeight().map(target < _).getOrElse(true) && (target == targetLimit) ==> bottomHeight().isEmpty))
 
     @pure
-    def removeBottom(): (LightBlock, UntrustedState) = {
+    def pop(): (LightBlock, UntrustedState) = {
       require(bottomHeight().isDefined)
       ??? : (LightBlock, UntrustedState)
     }.ensuring(res =>
@@ -40,7 +40,7 @@ object UntrustedStates {
         res._2.bottomHeight().map(bottomHeight().get < _).getOrElse(true))
 
     @pure
-    def insertLightBlock(lightBlock: LightBlock): UntrustedState = {
+    def push(lightBlock: LightBlock): UntrustedState = {
       require(
         bottomHeight().map(lightBlock.header.height < _).getOrElse(true) &&
           lightBlock.header.height <= targetLimit)
@@ -73,13 +73,13 @@ object UntrustedStates {
     }
 
     @pure
-    override def removeBottom(): (LightBlock, UntrustedState) = {
+    override def pop(): (LightBlock, UntrustedState) = {
       require(bottomHeight().isDefined)
       (pending.head, InMemoryUntrustedState(targetLimit, pending.tail))
     }
 
     @pure
-    override def insertLightBlock(lightBlock: LightBlock): UntrustedState = {
+    override def push(lightBlock: LightBlock): UntrustedState = {
       require(
         bottomHeight().map(lightBlock.header.height < _).getOrElse(true)
           && lightBlock.header.height <= targetLimit)

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/LightClientLemmas.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/LightClientLemmas.scala
@@ -10,7 +10,7 @@ object LightClientLemmas {
   @pure
   def terminationMeasure(waitingForHeader: WaitingForHeader): (BigInt, BigInt) = {
     val res: (BigInt, BigInt) = (
-      waitingForHeader.untrustedState.targetLimit.value - waitingForHeader.verifiedState.currentHeight().value,
+      waitingForHeader.fetchedStack.targetLimit.value - waitingForHeader.verifiedState.currentHeight().value,
       waitingForHeader.requestHeight.value - waitingForHeader.verifiedState.currentHeight().value
     )
     res
@@ -19,7 +19,7 @@ object LightClientLemmas {
   @opaque
   def sameVerifiedStateTerminationMeasure(previous: WaitingForHeader, current: WaitingForHeader): Unit = {
     require(
-      previous.untrustedState.targetLimit == current.untrustedState.targetLimit &&
+      previous.fetchedStack.targetLimit == current.fetchedStack.targetLimit &&
         previous.verifiedState.currentHeight() == current.verifiedState.currentHeight() &&
         previous.requestHeight > current.requestHeight)
   }.ensuring { _ =>
@@ -33,7 +33,7 @@ object LightClientLemmas {
   @opaque
   def improvedVerifiedStateLemma(previous: WaitingForHeader, current: WaitingForHeader): Unit = {
     require(
-      previous.untrustedState.targetLimit == current.untrustedState.targetLimit &&
+      previous.fetchedStack.targetLimit == current.fetchedStack.targetLimit &&
         previous.verifiedState.currentHeight() < current.verifiedState.currentHeight())
   }.ensuring { _ =>
     val previousTerminationMeasure = terminationMeasure(previous)

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/MultiStepVerifier.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/MultiStepVerifier.scala
@@ -17,23 +17,23 @@ case class MultiStepVerifier(
   verifier: Verifier,
   heightCalculator: NextHeightCalculator) {
 
-  def verifyUntrusted(verifiedState: VerifiedState, untrustedState: FetchedStack): Finished = {
+  def verifyUntrusted(verifiedState: VerifiedState, fetchedStack: FetchedStack): Finished = {
     require(
-      verifiedState.currentHeight() <= untrustedState.targetLimit &&
-        untrustedState.peek().isEmpty &&
-        untrustedState.targetLimit <= lightBlockProvider.currentHeight)
+      verifiedState.currentHeight() <= fetchedStack.targetLimit &&
+        fetchedStack.peek().isEmpty &&
+        fetchedStack.targetLimit <= lightBlockProvider.currentHeight)
 
-    if (verifiedState.currentHeight() == untrustedState.targetLimit)
-      Finished(Left(()), verifiedState, untrustedState)
+    if (verifiedState.currentHeight() == fetchedStack.targetLimit)
+      Finished(Left(()), verifiedState, fetchedStack)
     else {
-      val nextHeight = untrustedState.targetLimit
-      verify(WaitingForHeader(nextHeight, verifiedState, untrustedState))
+      val nextHeight = fetchedStack.targetLimit
+      verify(WaitingForHeader(nextHeight, verifiedState, fetchedStack))
     }
   }
 
   @scala.annotation.tailrec
   private def verify(waitingForHeader: WaitingForHeader): Finished = {
-    require(waitingForHeader.untrustedState.targetLimit <= lightBlockProvider.currentHeight)
+    require(waitingForHeader.fetchedStack.targetLimit <= lightBlockProvider.currentHeight)
     decreases(LightClientLemmas.terminationMeasure(waitingForHeader))
 
     processHeader(waitingForHeader, lightBlockProvider.lightBlock(waitingForHeader.requestHeight)) match {
@@ -45,7 +45,7 @@ case class MultiStepVerifier(
   private def processHeader(waitingForHeader: WaitingForHeader, lightBlock: LightBlock): VerifierState = {
     require(lightBlock.header.height == waitingForHeader.requestHeight)
 
-    stepByStepVerification(lightBlock, waitingForHeader.verifiedState, waitingForHeader.untrustedState)
+    stepByStepVerification(lightBlock, waitingForHeader.verifiedState, waitingForHeader.fetchedStack)
   }.ensuring {
     case state: WaitingForHeader =>
       if (waitingForHeader.verifiedState.currentHeight() == state.verifiedState.currentHeight())
@@ -58,7 +58,7 @@ case class MultiStepVerifier(
       ((previousTerminationMeasure._1 > currentTerminationMeasure._1) ||
       (previousTerminationMeasure._1 == currentTerminationMeasure._1 &&
       previousTerminationMeasure._2 > currentTerminationMeasure._2)) &&
-      state.untrustedState.targetLimit == waitingForHeader.untrustedState.targetLimit
+      state.fetchedStack.targetLimit == waitingForHeader.fetchedStack.targetLimit
 
     case _: Finished => true
   }
@@ -66,45 +66,45 @@ case class MultiStepVerifier(
   private def stepByStepVerification(
     lightBlock: LightBlock,
     verifiedState: VerifiedState,
-    untrustedState: FetchedStack): VerifierState = {
+    fetchedStack: FetchedStack): VerifierState = {
     require(
-      lightBlock.header.height <= untrustedState.targetLimit &&
+      lightBlock.header.height <= fetchedStack.targetLimit &&
         verifiedState.currentHeight() < lightBlock.header.height &&
-        untrustedState.peek().map(lightBlock.header.height < _.header.height).getOrElse(true))
-    decreases(untrustedState.targetLimit.value - verifiedState.currentHeight().value)
+        fetchedStack.peek().map(lightBlock.header.height < _.header.height).getOrElse(true))
+    decreases(fetchedStack.targetLimit.value - verifiedState.currentHeight().value)
 
     verifier.verify(verifiedState, lightBlock) match {
       case VerificationOutcomes.Success =>
         val newVerifiedState = verifiedState.increaseTrust(lightBlock)
-        if (newVerifiedState.currentHeight() == untrustedState.targetLimit) {
+        if (newVerifiedState.currentHeight() == fetchedStack.targetLimit) {
           val result = Left[Unit, VerificationError](())
-          Finished(result, newVerifiedState, untrustedState)
-        } else if (untrustedState.peek().isDefined) {
-          val (nextLightBlock, nextUntrustedState) = untrustedState.pop()
-          stepByStepVerification(nextLightBlock, newVerifiedState, nextUntrustedState)
-        } else if (newVerifiedState.currentHeight() + 1 == untrustedState.targetLimit)
-          WaitingForHeader(untrustedState.targetLimit, newVerifiedState, untrustedState)
+          Finished(result, newVerifiedState, fetchedStack)
+        } else if (fetchedStack.peek().isDefined) {
+          val (nextLightBlock, nextFetchedStack) = fetchedStack.pop()
+          stepByStepVerification(nextLightBlock, newVerifiedState, nextFetchedStack)
+        } else if (newVerifiedState.currentHeight() + 1 == fetchedStack.targetLimit)
+          WaitingForHeader(fetchedStack.targetLimit, newVerifiedState, fetchedStack)
         else {
           val newTargetHeight = heightCalculator.nextHeight(
             newVerifiedState.currentHeight(),
-            untrustedState.peek().map(_.header.height).getOrElse(untrustedState.targetLimit))
-          WaitingForHeader(newTargetHeight, newVerifiedState, untrustedState)
+            fetchedStack.peek().map(_.header.height).getOrElse(fetchedStack.targetLimit))
+          WaitingForHeader(newTargetHeight, newVerifiedState, fetchedStack)
         }
 
       case VerificationOutcomes.InsufficientTrust =>
         val nextHeight = heightCalculator.nextHeight(verifiedState.currentHeight(), lightBlock.header.height)
-        val nextUntrustedState = untrustedState.push(lightBlock)
-        WaitingForHeader(nextHeight, verifiedState, nextUntrustedState)
+        val nextFetchedStack = fetchedStack.push(lightBlock)
+        WaitingForHeader(nextHeight, verifiedState, nextFetchedStack)
 
       case Failure(reason) =>
         val error = Right[Unit, VerificationError](reason)
-        val newUntrustedState = untrustedState.push(lightBlock)
+        val newFetchedStack = fetchedStack.push(lightBlock)
 
-        Finished(error, verifiedState, newUntrustedState)
+        Finished(error, verifiedState, newFetchedStack)
     }
   }.ensuring {
     case waitingForHeader: WaitingForHeader =>
-      waitingForHeader.untrustedState.targetLimit == untrustedState.targetLimit &&
+      waitingForHeader.fetchedStack.targetLimit == fetchedStack.targetLimit &&
         waitingForHeader.verifiedState.currentHeight() >= verifiedState.currentHeight() &&
         (waitingForHeader.verifiedState.currentHeight() > verifiedState.currentHeight() ||
           waitingForHeader.requestHeight < lightBlock.header.height)

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/VerifierStates.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/VerifierStates.scala
@@ -13,23 +13,20 @@ object VerifierStates {
   sealed abstract class VerifierState
 
   @inlineInvariant
-  case class Finished(
-    outcome: Either[Unit, VerificationError],
-    verifiedState: VerifiedState,
-    untrustedState: FetchedStack)
+  case class Finished(outcome: Either[Unit, VerificationError], verifiedState: VerifiedState, fetchedStack: FetchedStack)
       extends VerifierState {
     require(
-      (outcome.isLeft && verifiedState.currentHeight() == untrustedState.targetLimit) ||
-        (outcome.isRight && verifiedState.currentHeight() < untrustedState.targetLimit))
+      (outcome.isLeft && verifiedState.currentHeight() == fetchedStack.targetLimit) ||
+        (outcome.isRight && verifiedState.currentHeight() < fetchedStack.targetLimit))
   }
 
   @inlineInvariant
-  case class WaitingForHeader(requestHeight: Height, verifiedState: VerifiedState, untrustedState: FetchedStack)
+  case class WaitingForHeader(requestHeight: Height, verifiedState: VerifiedState, fetchedStack: FetchedStack)
       extends VerifierState {
     require(
-      untrustedState.peek().map(requestHeight < _.header.height).getOrElse(true) &&
+      fetchedStack.peek().map(requestHeight < _.header.height).getOrElse(true) &&
         verifiedState.currentHeight() < requestHeight &&
-        requestHeight <= untrustedState.targetLimit)
+        requestHeight <= fetchedStack.targetLimit)
   }
 
 }

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/VerifierStates.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/VerifierStates.scala
@@ -1,6 +1,6 @@
 package ch.epfl.ognjanovic.stevan.tendermint.verified.light
 
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStates.UntrustedState
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.UntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.VerificationError
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.VerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.Height

--- a/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/VerifierStates.scala
+++ b/light-client-core/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/VerifierStates.scala
@@ -1,6 +1,6 @@
 package ch.epfl.ognjanovic.stevan.tendermint.verified.light
 
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.UntrustedState
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.FetchedStack
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.VerificationError
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.VerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.Height
@@ -16,7 +16,7 @@ object VerifierStates {
   case class Finished(
     outcome: Either[Unit, VerificationError],
     verifiedState: VerifiedState,
-    untrustedState: UntrustedState)
+    untrustedState: FetchedStack)
       extends VerifierState {
     require(
       (outcome.isLeft && verifiedState.currentHeight() == untrustedState.targetLimit) ||
@@ -24,10 +24,10 @@ object VerifierStates {
   }
 
   @inlineInvariant
-  case class WaitingForHeader(requestHeight: Height, verifiedState: VerifiedState, untrustedState: UntrustedState)
+  case class WaitingForHeader(requestHeight: Height, verifiedState: VerifiedState, untrustedState: FetchedStack)
       extends VerifierState {
     require(
-      untrustedState.bottomHeight().map(requestHeight < _).getOrElse(true) &&
+      untrustedState.peek().map(requestHeight < _.header.height).getOrElse(true) &&
         verifiedState.currentHeight() < requestHeight &&
         requestHeight <= untrustedState.targetLimit)
   }

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
@@ -2,14 +2,14 @@ package ch.epfl.ognjanovic.stevan.tendermint.light
 
 import ch.epfl.ognjanovic.stevan.tendermint.hashing.Hashers.Hasher
 import ch.epfl.ognjanovic.stevan.tendermint.light.ForkDetection._
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.UntrustedState
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.FetchedStack
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.MultiStepVerifier
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.ExpiredVerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.VerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.{Height, LightBlock, PeerId}
 import stainless.lang
 
-sealed class DefaultForkDetector(private val hasher: Hasher, private val untrustedStateSupplier: Height ⇒ UntrustedState)
+sealed class DefaultForkDetector(private val hasher: Hasher, private val untrustedStateSupplier: Height ⇒ FetchedStack)
     extends ForkDetector {
 
   override def detectForks(

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
@@ -9,7 +9,7 @@ import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.Verifi
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.{Height, LightBlock, PeerId}
 import stainless.lang
 
-sealed class DefaultForkDetector(private val hasher: Hasher, private val untrustedStateSupplier: Height ⇒ FetchedStack)
+sealed class DefaultForkDetector(private val hasher: Hasher, private val fetchedStackSupplier: Height ⇒ FetchedStack)
     extends ForkDetector {
 
   override def detectForks(
@@ -28,7 +28,7 @@ sealed class DefaultForkDetector(private val hasher: Hasher, private val untrust
       else {
         val witnessVerificationResult = witness.verifyUntrusted(
           verifiedStateSupplier(witnessBlock.peerId),
-          untrustedStateSupplier(targetLightBlock.header.height)
+          fetchedStackSupplier(targetLightBlock.header.height)
         )
 
         witnessVerificationResult.outcome match {

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/DefaultForkDetector.scala
@@ -2,8 +2,8 @@ package ch.epfl.ognjanovic.stevan.tendermint.light
 
 import ch.epfl.ognjanovic.stevan.tendermint.hashing.Hashers.Hasher
 import ch.epfl.ognjanovic.stevan.tendermint.light.ForkDetection._
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.UntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.MultiStepVerifier
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStates.UntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors.ExpiredVerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.VerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.{Height, LightBlock, PeerId}

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
@@ -7,10 +7,10 @@ import ch.epfl.ognjanovic.stevan.tendermint.light.Supervisor._
 import ch.epfl.ognjanovic.stevan.tendermint.light.store.LightStore
 import ch.epfl.ognjanovic.stevan.tendermint.light.LightBlockStatuses.Trusted
 import ch.epfl.ognjanovic.stevan.tendermint.verified.fork.{PeerList ⇒ GenericPeerList}
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.UntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockProviders.LightBlockProvider
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.MultiStepVerifierFactories.MultiStepVerifierFactory
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.TimeValidatorFactories.TimeValidatorConfig
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStates.UntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.VerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VotingPowerVerifiers.VotingPowerVerifier
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.{Height, LightBlock, PeerId}

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
@@ -28,7 +28,7 @@ object EventLoopClient {
     @volatile private var peerList: PeerList,
     private val votingPowerVerifier: VotingPowerVerifier,
     private val verifierBuilder: MultiStepVerifierFactory,
-    private val untrustedStateSupplier: Height ⇒ FetchedStack,
+    private val fetchedStackSupplier: Height ⇒ FetchedStack,
     private val timeValidatorConfig: TimeValidatorConfig,
     private val lightStore: LightStore,
     private val forkDetector: ForkDetector,
@@ -74,7 +74,7 @@ object EventLoopClient {
       val primaryResult =
         primaryVerifier.verifyUntrusted(
           primaryVerifiedState,
-          untrustedStateSupplier(height.getOrElse(peerList.primary.currentHeight)))
+          fetchedStackSupplier(height.getOrElse(peerList.primary.currentHeight)))
 
       primaryResult.outcome match {
         case lang.Left(_) ⇒

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/light/EventLoopClient.scala
@@ -7,7 +7,7 @@ import ch.epfl.ognjanovic.stevan.tendermint.light.Supervisor._
 import ch.epfl.ognjanovic.stevan.tendermint.light.store.LightStore
 import ch.epfl.ognjanovic.stevan.tendermint.light.LightBlockStatuses.Trusted
 import ch.epfl.ognjanovic.stevan.tendermint.verified.fork.{PeerList ⇒ GenericPeerList}
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.UntrustedState
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.FetchedStack
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockProviders.LightBlockProvider
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.MultiStepVerifierFactories.MultiStepVerifierFactory
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.TimeValidatorFactories.TimeValidatorConfig
@@ -28,7 +28,7 @@ object EventLoopClient {
     @volatile private var peerList: PeerList,
     private val votingPowerVerifier: VotingPowerVerifier,
     private val verifierBuilder: MultiStepVerifierFactory,
-    private val untrustedStateSupplier: Height ⇒ UntrustedState,
+    private val untrustedStateSupplier: Height ⇒ FetchedStack,
     private val timeValidatorConfig: TimeValidatorConfig,
     private val lightStore: LightStore,
     private val forkDetector: ForkDetector,

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/FetchedStackFactories.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/FetchedStackFactories.scala
@@ -3,13 +3,13 @@ package ch.epfl.ognjanovic.stevan.tendermint.verified.light
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.{FetchedStack, InMemoryFetchedStack}
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.Height
 
-object UntrustedStateFactories {
+object FetchedStackFactories {
 
-  trait UntrustedStateFactory {
+  trait FetchedStackFactory {
     def emptyWithTarget(target: Height): FetchedStack
   }
 
-  sealed class InMemoryUntrustedStateFactory extends UntrustedStateFactory {
+  sealed class InMemoryFetchedStackFactory extends FetchedStackFactory {
 
     override def emptyWithTarget(target: Height): FetchedStack =
       InMemoryFetchedStack(target, stainless.collection.List.empty)

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/UntrustedStateFactories.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/UntrustedStateFactories.scala
@@ -1,6 +1,6 @@
 package ch.epfl.ognjanovic.stevan.tendermint.verified.light
 
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStates.{InMemoryUntrustedState, UntrustedState}
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.{InMemoryUntrustedState, UntrustedState}
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.Height
 
 object UntrustedStateFactories {

--- a/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/UntrustedStateFactories.scala
+++ b/light-client/src/main/scala/ch/epfl/ognjanovic/stevan/tendermint/verified/light/UntrustedStateFactories.scala
@@ -1,18 +1,18 @@
 package ch.epfl.ognjanovic.stevan.tendermint.verified.light
 
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.{InMemoryUntrustedState, UntrustedState}
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.{FetchedStack, InMemoryFetchedStack}
 import ch.epfl.ognjanovic.stevan.tendermint.verified.types.Height
 
 object UntrustedStateFactories {
 
   trait UntrustedStateFactory {
-    def emptyWithTarget(target: Height): UntrustedState
+    def emptyWithTarget(target: Height): FetchedStack
   }
 
   sealed class InMemoryUntrustedStateFactory extends UntrustedStateFactory {
 
-    override def emptyWithTarget(target: Height): UntrustedState =
-      InMemoryUntrustedState(target, stainless.collection.List.empty)
+    override def emptyWithTarget(target: Height): FetchedStack =
+      InMemoryFetchedStack(target, stainless.collection.List.empty)
 
   }
 

--- a/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/MultiStepBisectionTests.scala
+++ b/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/MultiStepBisectionTests.scala
@@ -3,14 +3,14 @@ package ch.epfl.ognjanovic.stevan.tendermint.light
 import ch.epfl.ognjanovic.stevan.tendermint.light.cases.MultiStepTestCase
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.Deserializer
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.circe.CirceDeserializer
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStateFactories.InMemoryUntrustedStateFactory
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStackFactories.InMemoryFetchedStackFactory
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerificationErrors._
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VotingPowerVerifiers
 import org.scalatest.flatspec.AnyFlatSpec
 import stainless.lang._
 
 sealed class MultiStepBisectionTests extends AnyFlatSpec with VerifierTests {
-  private val untrustedStateFactory = new InMemoryUntrustedStateFactory()
+  private val fetchedStackFactory = new InMemoryFetchedStackFactory()
 
   implicit private val testCaseDeserializer: Deserializer[MultiStepTestCase] =
     new CirceDeserializer(MultiStepTestCase.decoder)
@@ -24,7 +24,7 @@ sealed class MultiStepBisectionTests extends AnyFlatSpec with VerifierTests {
     val verifier =
       multiStepVerifierFactory.constructVerifier(peerList.primary, votingPowerVerifier, timeValidatorConfig)
 
-    val result = verifier.verifyUntrusted(verifiedState, untrustedStateFactory.emptyWithTarget(heightToVerify))
+    val result = verifier.verifyUntrusted(verifiedState, fetchedStackFactory.emptyWithTarget(heightToVerify))
 
     assert(result.outcome.isLeft)
   }
@@ -36,7 +36,7 @@ sealed class MultiStepBisectionTests extends AnyFlatSpec with VerifierTests {
     val verifier =
       multiStepVerifierFactory.constructVerifier(peerList.primary, votingPowerVerifier, timeValidatorConfig)
 
-    val result = verifier.verifyUntrusted(verifiedState, untrustedStateFactory.emptyWithTarget(heightToVerify))
+    val result = verifier.verifyUntrusted(verifiedState, fetchedStackFactory.emptyWithTarget(heightToVerify))
 
     assert(result.outcome.isRight && result.outcome.get == ExpiredVerifiedState)
   }
@@ -45,7 +45,7 @@ sealed class MultiStepBisectionTests extends AnyFlatSpec with VerifierTests {
   //    val (verifier, verifiedState, heightToVerify) = MultiStepVerifierTests.deserializeMultiStepTestCase(
   //      "/bisection/single-peer/invalid_validator_set.json")
   //
-  //    val result = verifier.verifyUntrusted(verifiedState, untrustedStateFactory.emptyWithTarget(heightToVerify))
+  //    val result = verifier.verifyUntrusted(verifiedState, fetchedStackFactory.emptyWithTarget(heightToVerify))
   //
   //    assert(result == ExpiredVerifiedState)
   //  }
@@ -57,7 +57,7 @@ sealed class MultiStepBisectionTests extends AnyFlatSpec with VerifierTests {
     val verifier =
       multiStepVerifierFactory.constructVerifier(peerList.primary, votingPowerVerifier, timeValidatorConfig)
 
-    val result = verifier.verifyUntrusted(verifiedState, untrustedStateFactory.emptyWithTarget(heightToVerify))
+    val result = verifier.verifyUntrusted(verifiedState, fetchedStackFactory.emptyWithTarget(heightToVerify))
 
     assert(result.outcome.isRight && result.outcome.get == InsufficientCommitPower)
   }
@@ -70,7 +70,7 @@ sealed class MultiStepBisectionTests extends AnyFlatSpec with VerifierTests {
       multiStepVerifierFactory.constructVerifier(peerList.primary, votingPowerVerifier, timeValidatorConfig)
     buildTest(VerifierTests.testCase("/bisection/single-peer/worst_case.json"))
 
-    val result = verifier.verifyUntrusted(verifiedState, untrustedStateFactory.emptyWithTarget(heightToVerify))
+    val result = verifier.verifyUntrusted(verifiedState, fetchedStackFactory.emptyWithTarget(heightToVerify))
 
     assert(result.outcome == Left[Unit, VerificationError](()))
   }

--- a/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/SupervisorForkDetectionTests.scala
+++ b/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/SupervisorForkDetectionTests.scala
@@ -11,7 +11,7 @@ import ch.epfl.ognjanovic.stevan.tendermint.merkle.MerkleRoot
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.Deserializer
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.circe.CirceDeserializer
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.{DefaultVerifiedStateFactory, VotingPowerVerifiers}
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStateFactories.InMemoryUntrustedStateFactory
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStackFactories.InMemoryFetchedStackFactory
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStateFactory.{
   LightStoreBackedVerifiedStateConfiguration,
   SimpleVerifiedStateConfiguration
@@ -25,7 +25,7 @@ sealed class SupervisorForkDetectionTests extends AnyFlatSpec with VerifierTests
 
   private val lightStoreFactory = new DefaultLightStoreFactory()
 
-  private val untrustedStateFactory = new InMemoryUntrustedStateFactory()
+  private val fetchedStackFactory = new InMemoryFetchedStackFactory()
 
   implicit private val testCaseDeserializer: Deserializer[MultiStepTestCase] =
     new CirceDeserializer(MultiStepTestCase.decoder)
@@ -62,12 +62,12 @@ sealed class SupervisorForkDetectionTests extends AnyFlatSpec with VerifierTests
       peerList,
       votingPowerVerifier,
       multiStepVerifierFactory,
-      height ⇒ untrustedStateFactory.emptyWithTarget(height),
+      height ⇒ fetchedStackFactory.emptyWithTarget(height),
       timeValidatorConfig,
       lightStore,
       new DefaultForkDetector(
         new DefaultHasher(MerkleRoot.default()),
-        height ⇒ untrustedStateFactory.emptyWithTarget(height)),
+        height ⇒ fetchedStackFactory.emptyWithTarget(height)),
       primaryVerifiedStateBuilder,
       witnessVerifiedStateBuilder
     )
@@ -88,12 +88,12 @@ sealed class SupervisorForkDetectionTests extends AnyFlatSpec with VerifierTests
       peerList,
       votingPowerVerifier,
       multiStepVerifierFactory,
-      height ⇒ untrustedStateFactory.emptyWithTarget(height),
+      height ⇒ fetchedStackFactory.emptyWithTarget(height),
       timeValidatorConfig,
       lightStore,
       new DefaultForkDetector(
         new DefaultHasher(MerkleRoot.default()),
-        height ⇒ untrustedStateFactory.emptyWithTarget(height)),
+        height ⇒ fetchedStackFactory.emptyWithTarget(height)),
       primaryVerifiedStateBuilder,
       witnessVerifiedStateBuilder
     )
@@ -114,12 +114,12 @@ sealed class SupervisorForkDetectionTests extends AnyFlatSpec with VerifierTests
       peerList,
       votingPowerVerifier,
       multiStepVerifierFactory,
-      height ⇒ untrustedStateFactory.emptyWithTarget(height),
+      height ⇒ fetchedStackFactory.emptyWithTarget(height),
       timeValidatorConfig,
       lightStore,
       new DefaultForkDetector(
         new DefaultHasher(MerkleRoot.default()),
-        height ⇒ untrustedStateFactory.emptyWithTarget(height)),
+        height ⇒ fetchedStackFactory.emptyWithTarget(height)),
       primaryVerifiedStateBuilder,
       witnessVerifiedStateBuilder
     )
@@ -140,12 +140,12 @@ sealed class SupervisorForkDetectionTests extends AnyFlatSpec with VerifierTests
       peerList,
       votingPowerVerifier,
       multiStepVerifierFactory,
-      height ⇒ untrustedStateFactory.emptyWithTarget(height),
+      height ⇒ fetchedStackFactory.emptyWithTarget(height),
       timeValidatorConfig,
       lightStore,
       new DefaultForkDetector(
         new DefaultHasher(MerkleRoot.default()),
-        height ⇒ untrustedStateFactory.emptyWithTarget(height)),
+        height ⇒ fetchedStackFactory.emptyWithTarget(height)),
       primaryVerifiedStateBuilder,
       witnessVerifiedStateBuilder
     )

--- a/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/VerifierIntegrationTests.scala
+++ b/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/VerifierIntegrationTests.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.TendermintSingleNodeContainer
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.TendermintSingleNodeContainer.Def
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.InMemoryUntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockProviderFactories.{
   CachingLightBlockProviderFactory,
   DefaultLightBlockProviderFactory
@@ -16,7 +17,6 @@ import ch.epfl.ognjanovic.stevan.tendermint.verified.light.TimeValidatorFactorie
   DefaultTimeValidatorFactory,
   InstantTimeValidatorConfig
 }
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.UntrustedStates.InMemoryUntrustedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifiedStates.SimpleVerifiedState
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VerifierFactories.DefaultVerifierFactory
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.VotingPowerVerifiers

--- a/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/VerifierIntegrationTests.scala
+++ b/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/VerifierIntegrationTests.scala
@@ -78,7 +78,7 @@ sealed class VerifierIntegrationTests extends AnyFlatSpec with TestContainerForA
 
       assert(result.outcome.isLeft)
       assert(result.verifiedState.currentHeight() == heightToVerify)
-      assert(result.untrustedState.peek().isEmpty)
+      assert(result.fetchedStack.peek().isEmpty)
   }
 
   "Verifying one highest block with the state after verifying previous highest one" should "succeed" in withContainers {
@@ -116,7 +116,7 @@ sealed class VerifierIntegrationTests extends AnyFlatSpec with TestContainerForA
 
       assert(result.outcome.isLeft)
       assert(result.verifiedState.currentHeight() == heightToVerify)
-      assert(result.untrustedState.peek().isEmpty)
+      assert(result.fetchedStack.peek().isEmpty)
 
       while (primary.currentHeight == result.verifiedState.currentHeight()) {
         Thread.sleep(1000)
@@ -130,6 +130,6 @@ sealed class VerifierIntegrationTests extends AnyFlatSpec with TestContainerForA
 
       assert(result.outcome.isLeft)
       assert(result.verifiedState.currentHeight() == heightToVerify)
-      assert(result.untrustedState.peek().isEmpty)
+      assert(result.fetchedStack.peek().isEmpty)
   }
 }

--- a/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/VerifierIntegrationTests.scala
+++ b/light-client/src/test/scala/ch/epfl/ognjanovic/stevan/tendermint/light/VerifierIntegrationTests.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.TendermintSingleNodeContainer
 import ch.epfl.ognjanovic.stevan.tendermint.rpc.TendermintSingleNodeContainer.Def
-import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.InMemoryUntrustedState
+import ch.epfl.ognjanovic.stevan.tendermint.verified.light.FetchedStacks.InMemoryFetchedStack
 import ch.epfl.ognjanovic.stevan.tendermint.verified.light.LightBlockProviderFactories.{
   CachingLightBlockProviderFactory,
   DefaultLightBlockProviderFactory
@@ -74,11 +74,11 @@ sealed class VerifierIntegrationTests extends AnyFlatSpec with TestContainerForA
 
       val result = multiStepVerifier.verifyUntrusted(
         verifiedState,
-        InMemoryUntrustedState(heightToVerify, stainless.collection.List.empty))
+        InMemoryFetchedStack(heightToVerify, stainless.collection.List.empty))
 
       assert(result.outcome.isLeft)
       assert(result.verifiedState.currentHeight() == heightToVerify)
-      assert(result.untrustedState.bottomHeight().isEmpty)
+      assert(result.untrustedState.peek().isEmpty)
   }
 
   "Verifying one highest block with the state after verifying previous highest one" should "succeed" in withContainers {
@@ -112,11 +112,11 @@ sealed class VerifierIntegrationTests extends AnyFlatSpec with TestContainerForA
 
       var result = multiStepVerifier.verifyUntrusted(
         verifiedState,
-        InMemoryUntrustedState(heightToVerify, stainless.collection.List.empty))
+        InMemoryFetchedStack(heightToVerify, stainless.collection.List.empty))
 
       assert(result.outcome.isLeft)
       assert(result.verifiedState.currentHeight() == heightToVerify)
-      assert(result.untrustedState.bottomHeight().isEmpty)
+      assert(result.untrustedState.peek().isEmpty)
 
       while (primary.currentHeight == result.verifiedState.currentHeight()) {
         Thread.sleep(1000)
@@ -126,10 +126,10 @@ sealed class VerifierIntegrationTests extends AnyFlatSpec with TestContainerForA
 
       result = multiStepVerifier.verifyUntrusted(
         result.verifiedState,
-        InMemoryUntrustedState(heightToVerify, stainless.collection.List.empty))
+        InMemoryFetchedStack(heightToVerify, stainless.collection.List.empty))
 
       assert(result.outcome.isLeft)
       assert(result.verifiedState.currentHeight() == heightToVerify)
-      assert(result.untrustedState.bottomHeight().isEmpty)
+      assert(result.untrustedState.peek().isEmpty)
   }
 }


### PR DESCRIPTION
__Goals?__
Make the API more concise and logical, also align with the report.